### PR TITLE
Allow for preconfigured cache & log directories

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -119,11 +119,11 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.config.unwritable';
         }
 
-        if (!is_writable(str_replace('%kernel.root_dir%', $this->kernelRoot, $this->cache_path))) {
+        if (!is_writable($this->getCacheDir())) {
             $messages[] = 'mautic.install.cache.unwritable';
         }
 
-        if (!is_writable(str_replace('%kernel.root_dir%', $this->kernelRoot, $this->log_path))) {
+        if (!is_writable($this->getLogDir())) {
             $messages[] = 'mautic.install.logs.unwritable';
         }
 
@@ -284,5 +284,35 @@ class CheckStep implements StepInterface
         }
 
         return $parameters;
+    }
+    
+    private function getParameterLoader(): ParameterLoader
+    {
+        if ($this->parameterLoader) {
+            return $this->parameterLoader;
+        }
+
+        return $this->parameterLoader = new ParameterLoader();
+    }
+
+    public function getCacheDir(): string
+    {
+
+        if ($cachePath = $this->getParameterLoader()->getLocalParameterBag()->get('cache_path')) {
+            return str_replace('%kernel.root_dir%', $this->kernelRoot, $cachePath);
+        }
+        return dirname(__DIR__).'/var/cache/';
+
+    }
+
+    public function getLogDir(): string
+    {
+
+        if ($logPath = $this->getParameterLoader()->getLocalParameterBag()->get('log_path')) {
+            return str_replace('%kernel.root_dir%', $this->kernelRoot, $logPath);
+        }
+
+        return dirname(__DIR__).'/var/logs';
+
     }
 }


### PR DESCRIPTION
Currently the checkstep takes a very biased approach where logs and cache are placed. This allows for these configurations to be overridden in local parameters and be loaded in before installation time. 

Without this change, installing Mautic is not possible without first setting these folders to the "biased" location and only afterwards they can be moved.

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | "features" for all features, enhancements and bug fixes (until 3.3.0 is released) <!-- see below -->
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->


#### Steps to test this PR:
1. Create a new mautic project using mautic/recommended-project
1. Set a file parameters_local.php in app/config before installing mautic with the following content
<?php

```
$parameters = [
  'cache_path' => '%kernel.root_dir%/../../var/cache',
  'log_path' => '%kernel.root_dir%/../../var/logs',
  'mailer_spool_path' => '%kernel.root_dir%/../../var/spool',
  'tmp_path' => '%kernel.root_dir%/../../var/tmp',
  'db_server_version' => '5.7.32',
];
```
2. Make sure you remove the docroot/var folder
3. Try installing mautic
4. Without this patch, installing mautic will fail because it thinks the folder is not writeable. In reality it actually 
5. with this patch the installation will be able to continue
